### PR TITLE
add shallow true to reviews nesting

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root "pages#home"
 
   resources :locations, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
-    resources :reviews, only: [:create, :update, :destroy]
+    resources :reviews, only: [:create, :update, :destroy], shallow: true
     member do
       post   :favorite    # /locations/:id/favorite
       delete :unfavorite  # /locations/:id/unfavorite


### PR DESCRIPTION
shallow: true is a Rails routing option that tells Rails:

“Only require the parent resource’s ID (:location_id) when it actually makes sense (create/index/new). For actions that already identify the child uniquely (show/edit/update/destroy), don’t force me to include the parent.”