### PR TITLE
placeholder text darker

### DIFF
--- a/app/assets/stylesheets/components/_auth.scss
+++ b/app/assets/stylesheets/components/_auth.scss
@@ -22,7 +22,7 @@
   height: 52px;
   padding-left: 18px;
   &::placeholder {
-    color: #fff;
+    color: $secondary;
     opacity: 0.95;
     font-weight: 800;
   }


### PR DESCRIPTION
When focused:

<img width="383" height="354" alt="image" src="https://github.com/user-attachments/assets/9a024956-3faf-4449-aecf-5a207a2028cc" />

<img width="351" height="352" alt="image" src="https://github.com/user-attachments/assets/1ed8b0e8-4030-4ca5-b849-134054d96c6a" />
<img width="351" height="352" alt="image" src="https://github.com/user-attachments/assets/3961e3ae-9418-4e57-86f5-4977ca8e286c" />

